### PR TITLE
spi-pipe: include linux/ioctl.h for musl compatibility

### DIFF
--- a/src/spi-pipe.c
+++ b/src/spi-pipe.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <linux/ioctl.h>
 #include <linux/spi/spidev.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
When building spi-tools with a toolchain using the musl C library, it
currently breaks with an error such as:
spi-pipe.c:146:17: error: ‘_IOC_SIZEBITS’ undeclared

Including linux/ioctl.h before linux/spi/spidev.h fixes the problem, as
it can be seen by other musl-related patches for other projects.

This has also been tested with glibc and uclibc toolchains; these are
not affected by the change.

Signed-off-by: Erico Nunes nunes.erico@gmail.com
