### PR TITLE
spi-tools: do not use git version

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,7 @@
 bin_PROGRAMS = spi-config spi-pipe
 
-GIT_VERSION:=$(shell git describe --abbrev=10 --dirty --always)
-
 spi_config_SOURCES = spi-config.c
-spi_config_CFLAGS = -DVERSION=\"$(GIT_VERSION)\"
 spi_config_LDADD =
 
 spi_pipe_SOURCES = spi-pipe.c
-spi_pipe_CFLAGS = -DVERSION=\"$(GIT_VERSION)\"
 spi_pipe_LDADD = 

--- a/src/spi-config.c
+++ b/src/spi-config.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <linux/spi/spidev.h>
 #include <sys/ioctl.h>
+#include "config.h"
 
 static char * project = "spi-config";
 

--- a/src/spi-pipe.c
+++ b/src/spi-pipe.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <linux/spi/spidev.h>
 #include <sys/ioctl.h>
+#include "config.h"
 
 static char * project = "spi-pipe";
 


### PR DESCRIPTION
Using git version breaks the version when building outside of the
spi-tools git tree.
This can happen when building through an automation tool such as
Buildroot. For this case, a hack is necessary to avoid the git command,
as it performs the build after extracting a tarball and would break
otherwise.
spi-tools was recently added to Buildroot and the necessary hack is
shown in: https://patchwork.ozlabs.org/patch/547120

There is already a VERSION define inside the config.h header generated
by autotools, so my proposal is that this value gets used for the -v
parameter instead of the git return.

Signed-off-by: Erico Nunes nunes.erico@gmail.com
