### PR TITLE
Adds SPI_READY support and fixes a typo

### DIFF
--- a/src/spi-config.c
+++ b/src/spi-config.c
@@ -48,10 +48,10 @@ static void display_usage(const char * name)
 	fprintf(stderr, "    -d --device=<dev>  use the given spi-dev character device.\n");
 	fprintf(stderr, "    -q --query         print the current configuration.\n");
 	fprintf(stderr, "    -m --mode=[0-3]    use the selected spi mode:\n");
-	fprintf(stderr, "             0: low iddle level, sample on leading edge,\n");
-	fprintf(stderr, "             1: low iddle level, sample on trailing edge,\n");
-	fprintf(stderr, "             2: high iddle level, sample on leading edge,\n");
-	fprintf(stderr, "             3: high iddle level, sample on trailing edge.\n");
+	fprintf(stderr, "             0: low idle level, sample on leading edge,\n");
+	fprintf(stderr, "             1: low idle level, sample on trailing edge,\n");
+	fprintf(stderr, "             2: high idle level, sample on leading edge,\n");
+	fprintf(stderr, "             3: high idle level, sample on trailing edge.\n");
 	fprintf(stderr, "    -l --lsb={0,1}     LSB first (1) or MSB first (0).\n");
 	fprintf(stderr, "    -b --bits=[7...]   bits per word.\n");
 	fprintf(stderr, "    -s --speed=<int>   set the speed in Hz.\n");

--- a/src/spi-config.c
+++ b/src/spi-config.c
@@ -36,6 +36,7 @@ typedef struct spi_config {
 	int        lsb;   // {0,1}  (-1 when not configured).
 	int        bits;  // [7...] (-1 when not configured).
 	uint32_t   speed; // 0 when not configured.
+	int        spiready;   // {0,1}  (-1 when not configured).
 } spi_config_t;
 
 
@@ -54,6 +55,7 @@ static void display_usage(const char * name)
 	fprintf(stderr, "    -l --lsb={0,1}     LSB first (1) or MSB first (0).\n");
 	fprintf(stderr, "    -b --bits=[7...]   bits per word.\n");
 	fprintf(stderr, "    -s --speed=<int>   set the speed in Hz.\n");
+	fprintf(stderr, "    -r --spirdy={0,1}  consider SPI_RDY signal (1) or ignore it (0).\n");
 	fprintf(stderr, "    -h --help          this screen.\n");
 	fprintf(stderr, "    -v --version       display the version number.\n");
 
@@ -73,10 +75,11 @@ int main (int argc, char * argv[])
 		{"lsb",      required_argument, NULL,  'l' },
 		{"bits",     required_argument, NULL,  'b' },
 		{"speed",    required_argument, NULL,  's' },
+		{"spirdy",   required_argument, NULL,  'r' },
 		{0,         0,                 0,  0 }
 	};
 
-	spi_config_t  new_config = { -1, -1, -1, 0 };
+	spi_config_t  new_config = { -1, -1, -1, 0, -1 };
 	spi_config_t  config;
 	char *        device = NULL;
 	int           fd;
@@ -137,6 +140,15 @@ int main (int argc, char * argv[])
 				new_config.speed = val;
 				break;
 
+			case 'r':
+				if ((sscanf(optarg, "%d", & val) != 1)
+				 || (val < 0) || (val > 1)) {
+					fprintf(stderr, "%s: wrong SPI_RDY value ([0,1])\n", argv[0]);
+					exit(EXIT_FAILURE);
+				}
+				new_config.spiready = val;
+				break;
+
 			default:
 				fprintf(stderr, "%s: wrong option. Use -h for help.\n", argv[0]);
 				exit(EXIT_FAILURE);
@@ -160,6 +172,9 @@ int main (int argc, char * argv[])
 		exit(EXIT_FAILURE);
 	}
 	config.mode = byte;
+	config.spiready = ((config.mode & SPI_READY) ? 1 : 0);
+	// clear the upper flag bits to be left with mode number
+	config.mode &= 0x3;
 	if (ioctl(fd, SPI_IOC_RD_LSB_FIRST, & byte) < 0) {
 		perror("SPI_IOC_RD_LSB_FIRST");
 		exit(EXIT_FAILURE);
@@ -177,13 +192,23 @@ int main (int argc, char * argv[])
 	config.speed = u32;
 
 	if (query_only) {
-		fprintf(stdout, "%s: mode=%d, lsb=%d, bits=%d, speed=%d\n",
-		        device, config.mode, config.lsb, config.bits, config.speed);
+		fprintf(stdout, "%s: mode=%d, lsb=%d, bits=%d, speed=%d\n, spiready=%d",
+		        device, config.mode, config.lsb, config.bits, config.speed, config.spiready);
 		exit(EXIT_SUCCESS);
 	}
 
 	// Set the new configuration.
-	if ((config.mode != new_config.mode) && (new_config.mode != -1)) {
+	if ((config.spiready != new_config.spiready) && (new_config.spiready == 1)) {
+		new_config.mode |= SPI_READY;
+	}
+	if ((config.mode != new_config.mode) || (config.spiready != new_config.spiready)) {
+		// In case only the spiready flag was changed
+		if (new_config.mode == -1) {
+			new_config.mode = config.mode;
+		}
+		if (new_config.spiready == 1) {
+			new_config.mode |= SPI_READY;
+		}
 		byte = new_config.mode;
 		if (ioctl(fd, SPI_IOC_WR_MODE, & byte) < 0) {
 			perror("SPI_IOC_WR_MODE");

--- a/src/spi-config.c
+++ b/src/spi-config.c
@@ -192,7 +192,7 @@ int main (int argc, char * argv[])
 	config.speed = u32;
 
 	if (query_only) {
-		fprintf(stdout, "%s: mode=%d, lsb=%d, bits=%d, speed=%d\n, spiready=%d",
+		fprintf(stdout, "%s: mode=%d, lsb=%d, bits=%d, speed=%d, spiready=%d\n",
 		        device, config.mode, config.lsb, config.bits, config.speed, config.spiready);
 		exit(EXIT_SUCCESS);
 	}

--- a/src/spi-config.c
+++ b/src/spi-config.c
@@ -88,7 +88,7 @@ int main (int argc, char * argv[])
 	uint32_t      u32;
 	int           query_only = 0;
 
-	while ((opt = getopt_long(argc, argv, "d:qhvm:l:b:s:", options, &long_index)) >= 0) {
+	while ((opt = getopt_long(argc, argv, "d:qhvm:l:b:s:r:", options, &long_index)) >= 0) {
 		switch(opt) {
 			case 'q':
 				query_only = 1;


### PR DESCRIPTION
Many SPI master controllers support a co-called _SPI_READY_ signal. This patch adds support for it to the `spi-config` tool.