### PR TITLE
Add SPI speed control to spi-pipe

### DIFF
--- a/man/spi-pipe.1
+++ b/man/spi-pipe.1
@@ -13,8 +13,11 @@ data received from the SPI port.
 \fB\-d\fR, \fB\-\-device\fR=\fIDEVICE\fR
 use the given Linux spidev character device.
 .TP
+\fB\-s\fR, \fB\-\-speed\fR=\fI<int>\fR
+set the target SPI speed for transfer.
+.TP
 \fB\-b\fR, \fB\-\-blocksize\fR=\fI<int>\fR
-set the block size (in bytes) for transfert.
+set the block size (in bytes) for transfer.
 .TP
 \fB\-n\fR, \fB\-\-number\fR=\fI<int>\fR
 set the number of blocks to transmit (-1 for continuous transfert).


### PR DESCRIPTION
This PR adds a new option to -s/--speed option to spi-pipe for per-command speed settings. It allows for simpler experimentation with different SPI speeds on a target device, and also ensures that the SPI speed can be controlled on platforms where it gets reset on open() or close() operations.