### PR TITLE
enable SPI abuse

### DIFF
--- a/src/spi-pipe.c
+++ b/src/spi-pipe.c
@@ -93,7 +93,7 @@ int main (int argc, char * argv[])
 				break;
 			case 'b':
 				if ((sscanf(optarg, "%d", & blocksize) != 1)
-				 || (blocksize <= 0) || (blocksize > 16384)) {
+				 || (blocksize <= 0)) {
 					fprintf(stderr, "%s: wrong blocksize\n", argv[0]);
 					exit(EXIT_FAILURE);
 				}


### PR DESCRIPTION
I needed a block size MUCH larger than the maximum size hard-coded into `spi-pipe`, and had to remove this check for my application. I figured that it might be helpful to others to just remove the limit altogether, since it is possible (and sometimes useful) to run with very high block sizes.