### PR TITLE
Adjust the handling of SPI_IOC_RD_LSB_FIRST ioctl call

### DIFF
--- a/src/spi-tools.c
+++ b/src/spi-tools.c
@@ -45,7 +45,7 @@ int Read_spi_configuration(int fd, spi_config_t *config)
 		perror("SPI_IOC_RD_LSB_FIRST");
 		return -1;
 	}
-	config->lsb_first = (u8 == SPI_LSB_FIRST ? 1 : 0);
+	config->lsb_first = (u8 ? 1 : 0);
 
 	if (ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &u8) < 0) {
 		perror("SPI_IOC_RD_BITS_PER_WORD");


### PR DESCRIPTION
Adjust the handling of SPI_IOC_RD_LSB_FIRST ioctl call

In the https://www.kernel.org/doc/Documentation/spi/spidev
specification:

    "SPI_IOC_RD_LSB_FIRST, SPI_IOC_WR_LSB_FIRST ... pass a pointer to a byte
	which will return (RD) or assign (WR) the bit justification used to
	transfer SPI words.  Zero indicates MSB-first; other values indicate
	the less common LSB-first encoding.  In both cases the specified value
	is right-justified in each word, so that unused (TX) or undefined (RX)
	bits are in the MSBs."

    So the check of SPI_IOC_RD_LSB_FIRST parameter against SPI_LSB_FIRST
    was changed to check against non zero value.