### PR TITLE
Add Android.bp sample and update README for Android build instructions

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,96 @@
+# Android.bp for the spi-tools project.
+#
+# Copyright 2025  Parsa Majidi (parsa.majidi@kynetics.com)
+#
+# License  GPLv3+:  This is free software:  you are free to  change and
+# redistribute it.There is NO WARRANTY, to the extent permitted by law.
+
+// spi-tools
+
+
+genrule {
+    name: "generate_config_h",
+    srcs: [
+        "src/config.h.cmake.in"
+    ],
+    out: [
+        "config.h"
+    ],
+    cmd: "cp $(in) $(out)",
+}
+
+cc_library {
+    name: "spi-tools",
+    defaults: [
+        "spi_defaults",
+    ],
+    generated_headers: [
+        "generate_config_h",
+    ],
+    export_generated_headers: [
+        "generate_config_h",
+    ],
+}
+
+cc_defaults {
+    name: "spi_defaults",
+    device_specific: true,
+    cpp_std: "gnu++17",
+    cflags: [
+        // You may want to edit this with the version from configure.ac of
+        // the release you are using.
+        "-DGPIOD_VERSION_STR=\"unstable\"",
+    ],
+    cppflags: [
+        // Google C++ style is to not use exceptions, but this library does
+        // use them.
+        "-fexceptions",
+    ],
+    // Google C++ style is to not use runtime type information, but this
+    // library does use it.
+    rtti: true,
+}
+
+//
+// spi tools
+//
+
+phony {
+    name: "spi_tools",
+    required: [
+        "spi-config",
+	"spi-pipe",
+    ],
+}
+
+cc_binary {
+    name: "spi-config",
+    defaults: [
+        "spi_defaults",
+        "spi_tools_defaults",
+    ],
+    srcs: [
+        "src/spi-config.c",
+    ],
+}
+
+cc_binary {
+    name: "spi-pipe",
+    defaults: [
+        "spi_defaults",
+        "spi_tools_defaults",
+    ],
+    srcs: [
+        "src/spi-pipe.c",
+    ],
+}
+
+cc_defaults {
+    name: "spi_tools_defaults",
+    srcs: [
+        "src/spi-tools.c",
+    ],
+    shared_libs: [
+        "spi-tools",
+    ],
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ You can use `make uninstall` (with `sudo`) to remove the installed files.
 * `-h --help`          help screen.
 * `-v --version`       display the version number.
 
+* Some examples using a build folder under the source tree root:
+
+Android : `cmake -DCMAKE_TOOLCHAIN_FILE=~/Android/Sdk/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-21 -DANDROID_ABI=armeabi-v7a .. && make`
+
 #### Read the current configuration
 
 ```


### PR DESCRIPTION
This pull request includes the following updates to the spi-tools repository:

Added sample Android.bp file: This addition enables the spi-tools project to be built within an Android tree. It provides the necessary configurations for integrating spi-tools into an Android-based build system, making it easier to use the tools within Android projects.

Updated README.md: The README has been updated with an example demonstrating how to build the spi-tools binaries for Android devices. This addition aims to improve the documentation and provide clear instructions for users looking to compile and use spi-tools in Android environments.

These changes enhance the usability of the project for Android developers and make it easier to integrate the tools into Android-based workflows.